### PR TITLE
Save header elements to xaml tag.

### DIFF
--- a/src/HtmlToXamlConverter/HtmlToXamlConverter.cs
+++ b/src/HtmlToXamlConverter/HtmlToXamlConverter.cs
@@ -20,7 +20,7 @@ namespace HTMLConverter
 
     using System.Windows; // DependencyProperty
     using System.Windows.Documents; // TextElement
-  
+
     /// <summary>
     /// HtmlToXamlConverter is a static class that takes an HTML string
     /// and converts it into XAML
@@ -213,14 +213,18 @@ namespace HTMLConverter
                         AddSection(xamlParentElement, htmlElement, inheritedProperties, stylesheet, sourceContext);
                         break;
 
-                    // Paragraphs:
-                    case "p":
+                    // Headers;
                     case "h1":
                     case "h2":
                     case "h3":
                     case "h4":
                     case "h5":
                     case "h6":
+                        AddParagraph(xamlParentElement, htmlElement, inheritedProperties, stylesheet, sourceContext, htmlElementName);
+                        break;
+
+                    // Paragraphs:
+                    case "p":
                     case "nsrtitle":
                     case "textarea":
                     case "dd": // ???
@@ -404,7 +408,7 @@ namespace HTMLConverter
         /// <param name="sourceContext"></param>
         /// true indicates that a content added by this call contains at least one block element
         /// </param>
-        private static void AddParagraph(XmlElement xamlParentElement, XmlElement htmlElement, Hashtable inheritedProperties, CssStylesheet stylesheet, List<XmlElement> sourceContext)
+        private static void AddParagraph(XmlElement xamlParentElement, XmlElement htmlElement, Hashtable inheritedProperties, CssStylesheet stylesheet, List<XmlElement> sourceContext, string tag = null)
         {
             // Create currentProperties as a compilation of local and inheritedProperties, set localProperties
             Hashtable localProperties;
@@ -413,6 +417,11 @@ namespace HTMLConverter
             // Create a XAML element corresponding to this html element
             XmlElement xamlElement = xamlParentElement.OwnerDocument.CreateElement(/*prefix:*/null, /*localName:*/HtmlToXamlConverter.Xaml_Paragraph, _xamlNamespace);
             ApplyLocalProperties(xamlElement, localProperties, /*isBlock:*/true);
+
+            if (tag != null)
+            {
+                xamlElement.SetAttribute("Tag", tag);
+            }
 
             // Recurse into element subtree
             for (XmlNode htmlChildNode = htmlElement.FirstChild; htmlChildNode != null; htmlChildNode = htmlChildNode.NextSibling)
@@ -565,7 +574,7 @@ namespace HTMLConverter
                 if (htmlNode is XmlElement)
                 {
                     string htmlChildName = ((XmlElement)htmlNode).LocalName.ToLower();
-                    if (HtmlSchema.IsInlineElement(htmlChildName) || HtmlSchema.IsBlockElement(htmlChildName) || 
+                    if (HtmlSchema.IsInlineElement(htmlChildName) || HtmlSchema.IsBlockElement(htmlChildName) ||
                         htmlChildName == "img" || htmlChildName == "br" || htmlChildName == "hr")
                     {
                         elementHasChildren = true;
@@ -842,7 +851,7 @@ namespace HTMLConverter
             {
                 AddListItem(xamlListElement, (XmlElement)htmlChildNode, inheritedProperties, stylesheet, sourceContext);
                 lastProcessedListItemElement = (XmlElement)htmlChildNode;
-                htmlChildNode = htmlChildNode.NextSibling;               
+                htmlChildNode = htmlChildNode.NextSibling;
                 htmlChildNodeName = htmlChildNode == null ? null : htmlChildNode.LocalName.ToLower();
             }
 
@@ -1242,13 +1251,13 @@ namespace HTMLConverter
 
                     // Advance
                     htmlChildNode = htmlChildNode.NextSibling;
-                    
+
                 }
                 else if (htmlChildNode.LocalName.ToLower() == "td")
                 {
                     // Tr element is not present. We create one and add td elements to it
                     XmlElement xamlTableRowElement = xamlTableBodyElement.OwnerDocument.CreateElement(null, Xaml_TableRow, _xamlNamespace);
-                    
+
                     // This is incorrect formatting and the column starts should not be set in this case
                     Debug.Assert(columnStarts == null);
 
@@ -1258,7 +1267,7 @@ namespace HTMLConverter
                         xamlTableBodyElement.AppendChild(xamlTableRowElement);
                     }
                 }
-                else 
+                else
                 {
                     // Not a tr or td  element. Ignore it.
                     // TODO: consider better recovery here
@@ -1334,7 +1343,7 @@ namespace HTMLConverter
                         Debug.Assert(columnIndex + columnSpan < columnStarts.Count);
 
                         xamlTableCellElement.SetAttribute(Xaml_TableCell_ColumnSpan, columnSpan.ToString());
-                        
+
                         // Apply row span
                         for (int spannedColumnIndex = columnIndex; spannedColumnIndex < columnIndex + columnSpan; spannedColumnIndex++)
                         {
@@ -1522,7 +1531,7 @@ namespace HTMLConverter
             ClearActiveRowSpans(activeRowSpans);
 
             XmlNode htmlChildNode = htmlTbodyElement.FirstChild;
-          
+
             // Analyze tr elements
             while (htmlChildNode != null && columnWidthsAvailable)
             {
@@ -1795,7 +1804,7 @@ namespace HTMLConverter
             return spannedColumnIndex;
         }
 
-        
+
         /// <summary>
         /// Used for clearing activeRowSpans array in the beginning/end of each tbody
         /// </summary>
@@ -1842,7 +1851,7 @@ namespace HTMLConverter
         {
             double columnWidth;
             double nextColumnStart;
-            
+
             // Parameter validation
             Debug.Assert(htmlTDElement.LocalName.ToLower() == "td" || htmlTDElement.LocalName.ToLower() == "th");
             Debug.Assert(columnStart >= 0);


### PR DESCRIPTION
Save header element names from the HTML to the tag property on the generated XAML paragraph elements. This allows the XAML consumer to base the paragraph's font size on the current font size (XAML equivalent of the em unit).
