### PR TITLE
Large entity codes now supplied as decoded int instead of overflowed char

### DIFF
--- a/src/HtmlToXamlConverter/HtmlToXamlConverter.csproj
+++ b/src/HtmlToXamlConverter/HtmlToXamlConverter.csproj
@@ -9,6 +9,7 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />


### PR DESCRIPTION
I've encountered a bug where some characters such as [U+1F602](https://codepoints.net/U+1F602) will overflow when cast from an int (128569) to a `char` type. In the case of U+1F602, this will cause the returned character to be [U+F602](https://codepoints.net/U+F602) instead.

This PR adds a check to see if the int value of the `_nextCharacter` char matches `_nextCharacterCode`, which will be false if an overflow occurs during the cast on line 369 (HtmlLexicalAnalyzer.cs). If so, the `_nextCharacterCode` is used with `HttpUtility.HtmlDecode` to convert the HTML representation the character (using the character code) into the correct character.